### PR TITLE
Heroku Button deploy

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
-web: vendor/bin/heroku-php-nginx -C nginx.conf public/
-release: if [ -n "$DB_HOST" ]; then php artisan migrate --force; fi
+web: $(composer config bin-dir)/heroku-php-nginx -C nginx.conf public/
+scheduler: php -d memory_limit=512M artisan queue:work --stop-when-empty
+release: if [ -n "${DB_HOST}${DATABASE_URL}" ]; then php artisan migrate --force && php artisan cache:clear; fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Meetable
 
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
 Meetable is a minimal events aggregator website.
 
 You can see a live version of this project at:
@@ -281,7 +283,7 @@ Configure your web server to proxy `/img/` to the imageproxy, e.g. for nginx:
 ```
 
 
-## Installing on Heroku
+## Installing on Heroku manually
 
 ```
 # Make sure to set the organization if you're adding this to an account that is not your personal account
@@ -305,19 +307,6 @@ git push heroku master
 
 heroku config:set ...
 ...
-
-# Set up a cron job to run the worker
-# Add the scheduler add-on
-heroku addons:create scheduler:standard
-
-# Configure it
-heroku addons:open scheduler
-
-# Add this command to the scheduler:
-# php artisan queue:work --stop-when-empty
-
-# If you need to, watch the logs:
-heroku logs --tail
 ```
 
 

--- a/app.json
+++ b/app.json
@@ -4,6 +4,38 @@
   "keywords": ["events", "community"],
   "repository": "https://github.com/aaronpk/Meetable",
   "addons": [
-      "heroku-redis"
+    "heroku-redis",
+    {
+      "plan": "cleardb:ignite"
+    }
+  ],
+  "env": {
+  },
+  "environments": {
+    "review": {
+      "env": {
+        "APP_DEBUG": {
+          "value": "true"
+        },
+        "APP_ENV": {
+          "value": "local"
+        }
+      }
+    }
+  },
+  "formation": {
+    "web": {
+      "quantity": 1,
+      "size": "free"
+    },
+    "scheduler": {
+      "quantity": 1,
+      "size": "free"
+    }
+  },
+  "buildpacks": [
+    {
+      "url": "heroku/php"
+    }
   ]
 }

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,9 @@
     "require": {
         "php": "^7.2",
         "ext-imagick": "*",
+        "ext-pdo": "*",
+        "ext-redis": "*",
+        "ext-pcntl": "*",
         "doctrine/dbal": "^2.9",
         "eluceo/ical": "^0.16",
         "fideloper/proxy": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a299cf03df672d7314b00e876088c4f1",
+    "content-hash": "cf5673410ef42b1ada0ccd32235b366b",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -6888,7 +6888,10 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^7.2",
-        "ext-imagick": "*"
+        "ext-imagick": "*",
+        "ext-pdo": "*",
+        "ext-redis": "*",
+        "ext-pcntl": "*"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
Adds Heroku push-button deploy (more or less)

It sets up a database which skips those steps in setup (also tested without by `heroku config:unset DATABASE_URL`)

It supports redis by troubleshooting error messages

It now supports values not in `.env.example` as well as replacing values and uncomment + replace values

It's driven by `SETUP_DONE` environment variable, so this is also added to the `.env.example` and commented out.

Skips generating a key if the one you use is not the canned value, which it will become if it's blank or falsey

Adjusted some views and added a route to test database from GET request during setup, so I can be sure that those with an invalid `DATABASE_URL` or `DATABASE_URL` incapable of connecting can manually override

app.json created with many options that are not in the installer

`Procfile` setup to run migrations etc

`composer.json` & `composer.lock` updated to include `ext-XYZ` entries for redis and scheduler queues

Removed parts of ENV I felt were too opinionated and could be handled by the installer