### PR TITLE
Return HTML only when explicitly requested

### DIFF
--- a/.env.testing
+++ b/.env.testing
@@ -1,0 +1,1 @@
+APP_KEY=base64:i46EKmK+pU0X4/nC8cMV+/f/Wsk5a34CajFU94KreCc=

--- a/app/Http/Controllers/ICSController.php
+++ b/app/Http/Controllers/ICSController.php
@@ -123,7 +123,7 @@ class ICSController extends BaseController
     }
 
     private function _isRequestFromBrowser(Request $request) {
-        return $request->accepts('text/html');
+        return 'text/html' === $request->prefers(['text/calendar', 'text/html']);
     }
 
     public function index(Request $request) {

--- a/tests/Feature/ICSContentNegotiationTest.php
+++ b/tests/Feature/ICSContentNegotiationTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ICSContentNegotiationTest extends TestCase
+{
+    public function testContentNegotiation()
+    {
+        // Request with default header (text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8) results in the ICS view, HTML.
+        $response = $this->get('/ics/2021/12/indieweb-create-day-vfsXwP8OTgkK.ics');
+        $response->assertViewIs('ics');
+        // Request with specific text/calendar header results in the ICS file.
+        $response = $this->withHeaders(['Accept' => 'text/calendar'])->get('/ics/2021/12/indieweb-create-day-vfsXwP8OTgkK.ics');
+        $response->assertOk();
+        $response->assertSee('BEGIN:VCALENDAR');
+        // Request accepting anything results in the ICS file.
+        $response = $this->withHeaders(['Accept' => '*/*'])->get('/ics/2021/12/indieweb-create-day-vfsXwP8OTgkK.ics');
+        $response->assertOk();
+        $response->assertSee('BEGIN:VCALENDAR');
+    }
+}


### PR DESCRIPTION
This might not be exactly how Laravel expects to be tested. But I did the best I could with some Laravel docs and a hodge-podge local environment.

The real change here is to have Laravel pick between `text/calendar` and `text/html`. This way Meetable only returns the HTML view when the HTML type actually wins. Should make the URL compatible with wget/curl/etc when no Accept or only a `*/*` value is supplied by returning the ICS file in those cases.