### PR TITLE
Add PWA support to Meetable

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,7 +4,7 @@
     "description": "An events app for the web",
     "icons": [
         {
-            "src": "/icons/android-chrome-192x192.png",
+            "src": "/images/icon-192.png",
             "sizes": "192x192",
             "type": "image/png"
         },

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,23 @@
+{
+    "name": "Meetable",
+    "short_name": "Meetable",
+    "description": "An events app for the web",
+    "icons": [
+        {
+            "src": "/icons/android-chrome-192x192.png",
+            "sizes": "192x192",
+            "type": "image/png"
+        },
+        {
+            "src": "/icons/android-chrome-512x512.png",
+            "sizes": "512x512",
+            "type": "image/png"
+        }
+    ],
+    "id": "/?source=pwa",
+    "start_url": "/?source=pwa",
+    "background_color": "#fff",
+    "display": "standalone",
+    "scope": "/",
+    "theme_color": "#fff"
+}

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -9,7 +9,7 @@
             "type": "image/png"
         },
         {
-            "src": "/icons/android-chrome-512x512.png",
+            "src": "/images/icon-512.png",
             "sizes": "512x512",
             "type": "image/png"
         }

--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -23,6 +23,8 @@ use App\Response;
 
     <link href="/assets/style.css" rel="stylesheet">
 
+    <link rel="manifest" href="/manifest.json">
+
 @if($favicon=Setting::value('favicon_url'))
     <link rel="shortcut icon" href="{{ $favicon }}">
 @endif


### PR DESCRIPTION
This PR adds a default `manifest.json` for use with Meetable. This manifest allows Meetable to run as a PWA.