### PR TITLE
Feature/custom cadences

### DIFF
--- a/app/Event.php
+++ b/app/Event.php
@@ -34,7 +34,7 @@ class Event extends Model
         'latitude', 'longitude', 'timezone', 'status',
         'website', 'tickets_url', 'code_of_conduct_url', 'meeting_url', 'video_url', 'notes_url',
         'summary', 'description', 'cover_image', 'unlisted', 'parent_id', 'hide_from_main_feed',
-        'recurrence_interval',
+        'recurrence_interval', 'recurrence_interval_count',
     ];
 
     public static function slug_from_name($name) {
@@ -424,6 +424,8 @@ class Event extends Model
                 return 'Every week on '.$start->format('l').'s';
             case 'biweekly_dow':
                 return 'Every other week on '.$start->format('l').'s';
+            case 'weekly_n':
+                return 'Every '.$this->recurrence_interval_count.' weeks on '.$start->format('l').'s';
             case 'monthly_date':
                 return 'Every month on the '.$start->format('dS');
             case 'yearly':
@@ -440,6 +442,8 @@ class Event extends Model
                 return new DateInterval('P1W');
             case 'biweekly_dow':
                 return new DateInterval('P2W');
+            case 'weekly_n':
+                return new DateInterval('P'.((int)$this->recurrence_interval_count ?: 1).'W');
             case 'monthly_date':
                 return new DateInterval('P1M');
             case 'yearly':
@@ -458,6 +462,8 @@ class Event extends Model
                 return $now->add(new DateInterval('P5W'));
             case 'biweekly_dow':
                 return $now->add(new DateInterval('P9W'));
+            case 'weekly_n':
+                return $now->add(new DateInterval('P'.(((int)$this->recurrence_interval_count ?: 1) * 5).'W'));
             case 'monthly_date':
                 return $now->add(new DateInterval('P4M'));
             case 'yearly':

--- a/app/Event.php
+++ b/app/Event.php
@@ -425,7 +425,7 @@ class Event extends Model
             case 'biweekly_dow':
                 return 'Every other week on '.$start->format('l').'s';
             case 'weekly_n':
-                return 'Every '.$this->recurrence_interval_count.' weeks on '.$start->format('l').'s';
+                return 'Every '.((int)$this->recurrence_interval_count ?: 1).' weeks on '.$start->format('l').'s';
             case 'monthly_date':
                 return 'Every month on the '.$start->format('dS');
             case 'yearly':

--- a/app/Event.php
+++ b/app/Event.php
@@ -502,6 +502,7 @@ class Event extends Model
                     $copy->start_date = $date->format('Y-m-d');
                     $copy->is_template = false;
                     $copy->recurrence_interval = null;
+                    $copy->recurrence_interval_count = null;
                     $copy->sort_date = $copy->sort_date();
                     $copy->reset_live_event_stats();
 

--- a/app/Event.php
+++ b/app/Event.php
@@ -425,7 +425,8 @@ class Event extends Model
             case 'biweekly_dow':
                 return 'Every other week on '.$start->format('l').'s';
             case 'weekly_n':
-                return 'Every '.((int)$this->recurrence_interval_count ?: 1).' weeks on '.$start->format('l').'s';
+                $weeks = (int)$this->recurrence_interval_count ?: 1;
+                return ($weeks == 1 ? 'Every week' : 'Every '.$weeks.' weeks').' on '.$start->format('l').'s';
             case 'monthly_date':
                 return 'Every month on the '.$start->format('dS');
             case 'yearly':

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -76,7 +76,9 @@ class EventController extends BaseController
         if(request('is_template')) {
             $event->is_template = true;
             $event->recurrence_interval = request('recurrence_interval');
-            $event->recurrence_interval_count = request('recurrence_interval_count') ?: null;
+            $event->recurrence_interval_count = request('recurrence_interval') === 'weekly_n'
+                ? (request('recurrence_interval_count') ?: null)
+                : null;
             $event->key = '';
         }
 
@@ -315,7 +317,9 @@ class EventController extends BaseController
         // Allow event templates to change the recurrence property
         if($event->is_template) {
             $event->recurrence_interval = request('recurrence_interval');
-            $event->recurrence_interval_count = request('recurrence_interval_count') ?: null;
+            $event->recurrence_interval_count = request('recurrence_interval') === 'weekly_n'
+                ? (request('recurrence_interval_count') ?: null)
+                : null;
         }
 
         $event->last_modified_by = Auth::user()->id;

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -65,6 +65,7 @@ class EventController extends BaseController
             'name' => 'required',
             'start_date' => 'required|date_format:Y-m-d',
             'status' => 'in:'.implode(',', array_keys(Event::$STATUSES)),
+            'recurrence_interval_count' => 'required_if:recurrence_interval,weekly_n|nullable|integer|min:1|max:52',
         ]);
 
         $event = new Event();
@@ -75,6 +76,7 @@ class EventController extends BaseController
         if(request('is_template')) {
             $event->is_template = true;
             $event->recurrence_interval = request('recurrence_interval');
+            $event->recurrence_interval_count = request('recurrence_interval_count') ?: null;
             $event->key = '';
         }
 
@@ -244,6 +246,7 @@ class EventController extends BaseController
             'name' => 'required',
             'start_date' => 'required|date_format:Y-m-d',
             'status' => 'in:'.implode(',', array_keys(Event::$STATUSES)),
+            'recurrence_interval_count' => 'required_if:recurrence_interval,weekly_n|nullable|integer|min:1|max:52',
         ]);
 
         if($event->fields_from_ics) {
@@ -312,6 +315,7 @@ class EventController extends BaseController
         // Allow event templates to change the recurrence property
         if($event->is_template) {
             $event->recurrence_interval = request('recurrence_interval');
+            $event->recurrence_interval_count = request('recurrence_interval_count') ?: null;
         }
 
         $event->last_modified_by = Auth::user()->id;

--- a/database/migrations/2026_06_10_000000_recurrence_interval_count.php
+++ b/database/migrations/2026_06_10_000000_recurrence_interval_count.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->unsignedInteger('recurrence_interval_count')->nullable();
+        });
+        Schema::table('event_revisions', function (Blueprint $table) {
+            $table->unsignedInteger('recurrence_interval_count')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->dropColumn('recurrence_interval_count');
+        });
+        Schema::table('event_revisions', function (Blueprint $table) {
+            $table->dropColumn('recurrence_interval_count');
+        });
+    }
+};

--- a/resources/views/edit-event.blade.php
+++ b/resources/views/edit-event.blade.php
@@ -246,6 +246,13 @@ form h2.subtitle {
     <script>
     $(function(){
         var selected_recurrence_interval;
+        var selected_recurrence_interval_count;
+        function toggle_count() {
+            if($("select[name=recurrence_interval]").val() == 'weekly_n')
+                $("#recurrence_count_field").show();
+            else
+                $("#recurrence_count_field").hide();
+        }
         function reload_recurrence_menu() {
             $.post("/event/{{ $event->id }}/recurring/details", {
                 _token: csrf_token(),
@@ -259,8 +266,18 @@ form h2.subtitle {
                     $("select[name=recurrence_interval]").val("{{ $event->recurrence_interval ?: 'weekly_dow' }}");
                 }
 
+                if(selected_recurrence_interval_count) {
+                    $("input[name=recurrence_interval_count]").val(selected_recurrence_interval_count);
+                }
+                toggle_count();
+
                 $("select[name=recurrence_interval]").on('change', function(){
                     selected_recurrence_interval = $(this).val();
+                    toggle_count();
+                });
+
+                $("input[name=recurrence_interval_count]").on('change', function(){
+                    selected_recurrence_interval_count = $(this).val();
                 });
             });
         }

--- a/resources/views/recurring-event-details.blade.php
+++ b/resources/views/recurring-event-details.blade.php
@@ -5,9 +5,17 @@
             <select name="recurrence_interval">
                 <option value="weekly_dow">Every Week on {{ $recur_dow }}</option>
                 <option value="biweekly_dow">Every Other Week on {{ $recur_dow }}</option>
+                <option value="weekly_n">Every N Weeks on {{ $recur_dow }}</option>
                 <option value="monthly_date">Every Month on the {{ $recur_date }}</option>
                 <option value="yearly">Every Year on {{ $recur_month_date }}</option>
             </select>
         </div>
+    </div>
+</div>
+<div class="field" id="recurrence_count_field" style="display:none;">
+    <label class="label">Repeat every how many weeks?</label>
+    <div class="control">
+        <input type="number" class="input" name="recurrence_interval_count"
+               min="1" max="52" value="{{ $event->recurrence_interval_count ?: 3 }}">
     </div>
 </div>

--- a/tests/Unit/EventTest.php
+++ b/tests/Unit/EventTest.php
@@ -174,4 +174,35 @@ class EventTest extends TestCase
         $now = new DateTime('2024-12-01T17:31:00');
         $this->assertTrue($event->is_past($now));
     }
+
+    public function testRecurrenceEveryNWeeksInterval() {
+        $event = new Event;
+        $event->start_date = '2024-01-01'; // a Monday
+        $event->recurrence_interval = 'weekly_n';
+        $event->recurrence_interval_count = 3;
+
+        // 'P3W' is normalized to 21 days internally
+        $this->assertEquals(21, $event->recurrence_date_interval()->d);
+        $this->assertEquals('Every 3 weeks on Mondays', $event->recurrence_description());
+    }
+
+    public function testRecurrenceEveryNWeeksEndWindow() {
+        $event = new Event;
+        $event->start_date = '2024-01-01';
+        $event->recurrence_interval = 'weekly_n';
+        $event->recurrence_interval_count = 3;
+
+        // Lookahead is count * 5 weeks = 15 weeks = 105 days ahead of "now"
+        $now = new DateTime();
+        $end = $event->recurrence_end_datetime();
+        $this->assertEquals(105, $now->diff($end)->days);
+    }
+
+    public function testRecurrenceEveryNWeeksFallsBackToWeekly() {
+        $event = new Event;
+        $event->start_date = '2024-01-01';
+        $event->recurrence_interval = 'weekly_n';
+        // No count set: should behave as every 1 week (7 days), not crash
+        $this->assertEquals(7, $event->recurrence_date_interval()->d);
+    }
 }


### PR DESCRIPTION
Some MCP groups meet every N weeks on a custom cadence that doesn't match either weekly or bi-weekly (such as MCP Apps).  This PR adds an option to set recurring events to every N weeks.

The workaround we use today: we create a weekly meeting, and then delete the occurrences we don't want.  That is a little awkward (and the events also tend to re-create themselves which cases confusion).  

Side note, if you'd prefer I try to fix the problem where deleted events come back from the dead, let me know and I can dig into that one instead.  That would let us keep using the workaround rather than potentially cluttering the UI with too many niche features.

Thanks!